### PR TITLE
Implement altitude-based sky color transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,6 +2,11 @@ let scene, camera, renderer, clock;
 let planet, ship, shipPivot;
 let stars;
 
+const skyColorNear = new THREE.Color(0x87ceeb); // light blue
+const spaceColor = new THREE.Color(0x000000); // black
+const skyTransitionStart = 20; // altitude where sky starts fading
+const skyTransitionEnd = 50; // altitude where space is fully visible
+
 const planetRadius = 50;
 let currentAltitude = 15; // Altitude above planet surface
 const shipSize = 2;
@@ -26,6 +31,7 @@ function init() {
   // Renderer
   renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setClearColor(spaceColor);
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   document.body.appendChild(renderer.domElement);
@@ -136,6 +142,8 @@ function createStars() {
   const starMaterial = new THREE.MeshBasicMaterial({
     map: createStarTexture(),
     side: THREE.BackSide,
+    transparent: true,
+    opacity: 1,
   });
   stars = new THREE.Mesh(starGeometry, starMaterial);
   scene.add(stars);
@@ -328,6 +336,19 @@ function animate() {
 
   // updateCamera();
   updateCameraStable();
+
+  // Adjust sky color based on altitude
+  const t = THREE.MathUtils.clamp(
+    (currentAltitude - skyTransitionStart) /
+      (skyTransitionEnd - skyTransitionStart),
+    0,
+    1
+  );
+  const newColor = skyColorNear.clone().lerp(spaceColor, t);
+  renderer.setClearColor(newColor);
+  if (stars && stars.material) {
+    stars.material.opacity = t;
+  }
 
   renderer.render(scene, camera);
 }


### PR DESCRIPTION
## Summary
- change stars to fade when near the planet
- set renderer clear color to blue near the planet and black in space
- initialize renderer with black clear color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841360d34a883249876837ed65e5601