### PR TITLE
Fix sky color transition

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -460,9 +460,10 @@ function animate() {
     1
   );
   const newColor = skyColorNear.clone().lerp(spaceColor, t);
-  renderer.setClearColor(newColor);
+  renderer.setClearColor(newColor, 1);
   if (stars && stars.material) {
     stars.material.opacity = t;
+    stars.material.needsUpdate = true;
   }
 
   renderer.render(scene, camera);


### PR DESCRIPTION
## Summary
- ensure background color clear alpha is set
- force star material to update when adjusting opacity

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841d40e555c8324ad5af747afc4effa